### PR TITLE
Fix contour extraction after closing figure

### DIFF
--- a/core/utils/slicer.py
+++ b/core/utils/slicer.py
@@ -589,9 +589,10 @@ def generate_contours(
         raw_xlim = ax.get_xlim()
         raw_ylim = ax.get_ylim()
         plt.savefig(os.path.join(debug_image_path, "contours.png"))
-        plt.close(fig)
 
     level_polys = _extract_level_polygons(cs)
+
+    plt.close(fig)
     contour_layers = _compute_layer_bands(level_polys, transform)
 
     if DEBUG:


### PR DESCRIPTION
## Summary
- prevent closing contour figure before polygon extraction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684c280ebb448326bc811d4acb07f014