### PR TITLE
Add num_layers option to contour generation

### DIFF
--- a/core/services/contour_generator.py
+++ b/core/services/contour_generator.py
@@ -105,6 +105,7 @@ class ContourSlicingJob:
             scale=100,
             bounds=self.bounds,
             fixed_elevation=self.fixed_elevation,
+            num_layers=self.num_layers,
         )
         _log_contour_info(contours, "After Contour Generation")
         # Project, smooth, and scale the contours


### PR DESCRIPTION
## Summary
- add `num_layers` argument to `_create_contourf_levels` and `generate_contours`
- forward `num_layers` from `ContourSlicingJob`
- update contour level tests for new argument
- patch tests for raster window mocking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2ed30fd08326a80ac8692803e7b8