### PR TITLE
Enable CSRF with CORS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ cp env.example .env   # edit DB credentials, secret key …
 docker compose up --build
 ```
 
-Visit **http://localhost:5173** in your browser.  
+Visit **http://localhost:5173** in your browser.
 The front‑end talks to the Django API at **http://localhost:8000**.
+The API enforces CSRF protection. Ensure your `.env` defines matching
+`DJANGO_CORS_ALLOWED_ORIGINS` and `DJANGO_CSRF_TRUSTED_ORIGINS`
+so the browser can send the `csrftoken` cookie with each request.
 
 ### Production
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -93,7 +93,14 @@ MIDDLEWARE = [
 ]
 
 CORS_ALLOWED_ORIGINS = get_env(
-    "DJANGO_CORS_ALLOWED_ORIGINS", "http://localhost:5173,http://localhost:4173"
+    "DJANGO_CORS_ALLOWED_ORIGINS",
+    "http://localhost:5173,http://localhost:4173,https://laserslicer.legradic.ch",
+).split(",")
+CORS_ALLOW_CREDENTIALS = True
+
+CSRF_TRUSTED_ORIGINS = get_env(
+    "DJANGO_CSRF_TRUSTED_ORIGINS",
+    "http://localhost:5173,http://localhost:4173,https://laserslicer.legradic.ch",
 ).split(",")
 
 ROOT_URLCONF = "config.urls"

--- a/core/views.py
+++ b/core/views.py
@@ -4,7 +4,6 @@ from functools import wraps
 from django.apps import apps
 from django.http import JsonResponse
 from django.shortcuts import render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 from rest_framework import status as drf_status
 from rest_framework.decorators import api_view
@@ -96,7 +95,6 @@ def waterbody(request):
     return JsonResponse({"in_water": False, "polygon": None})
 
 
-@csrf_exempt
 @api_view(["POST"])
 @safe_api
 def elevation_range(request) -> Response:
@@ -116,7 +114,6 @@ def elevation_range(request) -> Response:
     return Response({"job_id": str(job.id)}, status=202)
 
 
-@csrf_exempt
 @api_view(["POST"])
 @safe_api
 def export_svgs_job(request):
@@ -131,7 +128,6 @@ def export_svgs_job(request):
     return Response({"job_id": str(job.id)}, status=202)
 
 
-@csrf_exempt
 @api_view(["POST"])
 @safe_api
 def geocode(request) -> Response:
@@ -176,7 +172,6 @@ def _compute_center(bounds: dict) -> tuple[float, float]:
     return ((lon_min + lon_max) / 2, (lat_min + lat_max) / 2)
 
 
-@csrf_exempt
 @api_view(["POST"])
 @safe_api
 def slice_contours(request):

--- a/env.example
+++ b/env.example
@@ -7,6 +7,8 @@
 DJANGO_SECRET_KEY=dev-secret-key
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+DJANGO_CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173
+DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:5173,http://localhost:4173
 
 # PostgreSQL settings (for local DB server)
 POSTGRES_DB=laserslicer
@@ -37,6 +39,8 @@ VITE_API_URL=http://localhost:8000
 # DJANGO_SECRET_KEY=prod-secret-key
 # DJANGO_DEBUG=True
 # DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,backend
+# DJANGO_CORS_ALLOWED_ORIGINS=http://localhost:5173
+# DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:5173
 
 # POSTGRES_DB=laserslicer
 # POSTGRES_USER=laserslicer

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,19 @@ import MapView from './components/Mapview';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
+function getCookie(name: string): string {
+  const match = document.cookie.match('(^|;)\\s*' + name + '=([^;]*)');
+  return match ? decodeURIComponent(match[2]) : '';
+}
+
+function fetchWithCsrf(input: RequestInfo | URL, init: RequestInit = {}) {
+  const headers = {
+    'X-CSRFToken': getCookie('csrftoken'),
+    ...(init.headers || {})
+  } as HeadersInit;
+  return fetch(input, { ...init, credentials: 'include', headers });
+}
+
 // ──────────────────────────────────────────────────────────
 /**
  * SlicerParams
@@ -314,7 +327,7 @@ function App() {
         lon_max: bounds[1][1],
       }
     };
-    const res = await fetch(`${API_URL}/api/elevation-range/`, {
+    const res = await fetchWithCsrf(`${API_URL}/api/elevation-range/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -388,7 +401,7 @@ function App() {
    * @throws Error if geocoding fails or returns an error
    */
   async function fetchCoordinates(address: string, signal?: AbortSignal): Promise<[number, number]> {
-    const res = await fetch(`${API_URL}/api/geocode/`, {
+    const res = await fetchWithCsrf(`${API_URL}/api/geocode/`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ address }),
@@ -458,7 +471,7 @@ function App() {
     try {
       setSlicing(true);
       setContourLayers([]); // clear old result
-      const res = await fetch(`${API_URL}/api/slice/`, {
+      const res = await fetchWithCsrf(`${API_URL}/api/slice/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -487,7 +500,7 @@ function App() {
       return;
     }
     try {
-      const res = await fetch(`${API_URL}/api/export/`, {
+      const res = await fetchWithCsrf(`${API_URL}/api/export/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- enable CSRF protection by default
- configure trusted origins and allow credentials
- document new env vars
- send CSRF token from React app

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516a7896e88326a00da2bef067e575