### PR TITLE
feat: color roads by type

### DIFF
--- a/tests/test_osm_features.py
+++ b/tests/test_osm_features.py
@@ -35,11 +35,17 @@ from core.utils.osm_features import (
 
 
 def test_fetch_roads(monkeypatch):
-    gdf = gpd.GeoDataFrame({"geometry": [LineString([(0, 0), (1, 0)])]})
+    gdf = gpd.GeoDataFrame(
+        {
+            "geometry": [LineString([(0, 0), (1, 0)])],
+            "highway": ["residential"],
+        }
+    )
     monkeypatch.setattr("osmnx.geometries_from_polygon", lambda p, tags=None: gdf)
     result = fetch_roads((0, 0, 1, 1))
-    assert result.geom_type == "MultiLineString"
-    assert len(result.geoms) == 1
+    assert isinstance(result, dict) and "residential" in result
+    geom = result["residential"]
+    assert geom.geom_type == "MultiLineString" and len(geom.geoms) == 1
 
 
 def test_fetch_buildings(monkeypatch):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -161,7 +161,10 @@ def test_contour_slicing_job_with_osm(monkeypatch):
     monkeypatch.setattr(
         "core.services.contour_generator._log_contour_info", lambda *a, **k: None
     )
-    monkeypatch.setattr("core.services.contour_generator.fetch_roads", lambda b: ml)
+    monkeypatch.setattr(
+        "core.services.contour_generator.fetch_roads",
+        lambda b: {"residential": ml},
+    )
     monkeypatch.setattr("core.services.contour_generator.fetch_waterways", lambda b: ml)
     monkeypatch.setattr(
         "core.services.contour_generator.fetch_buildings",
@@ -185,7 +188,8 @@ def test_contour_slicing_job_with_osm(monkeypatch):
     )
     result = job.run()
     layer = result[0]
-    assert "roads" in layer
+    assert "roads" in layer and isinstance(layer["roads"], dict)
+    assert "residential" in layer["roads"]
     assert "buildings" in layer
     assert "waterways" in layer
 
@@ -232,7 +236,7 @@ def test_contour_slicing_job_empty_osm(monkeypatch):
     )
     monkeypatch.setattr(
         "core.services.contour_generator.fetch_roads",
-        lambda b: shapely.geometry.MultiLineString(),
+        lambda b: {},
     )
     monkeypatch.setattr(
         "core.services.contour_generator.fetch_waterways",


### PR DESCRIPTION
## Purpose
- propagate OSM road type info through the backend
- expose road type styles in SVG export and 3D preview

## Summary
- group roads by `highway` in `fetch_roads`
- project each road type in `ContourSlicingJob`
- draw each road type using its own color/width in SVG
- render road lines in preview using style map
- update unit tests

## Testing
- `ruff check core/services/contour_generator.py core/utils/osm_features.py core/utils/svg_export.py tests/test_osm_features.py tests/test_services.py`
- `npm run lint --prefix frontend` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_685531501ad88326ba09d2bc3f5b5dbc