### PR TITLE
Add SwissALTI3D backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laser Slicer – Laser‑Cuttable Contour Map Generator
 
-Turn any point on Earth into a **stack of precisely‑aligned SVG layers ready for laser cutting**.  
-Laser Slicer downloads SRTM elevation data, OSM features like roads and waterways, slices contours at the interval you choose, and gives you:
+Turn any point on Earth into a **stack of precisely‑aligned SVG layers ready for laser cutting**.
+Laser Slicer downloads high‑resolution SwissALTI3D data within Switzerland and falls back to global SRTM elevation data elsewhere. It fetches OSM features like roads and waterways, slices contours at the interval you choose, and gives you:
 
 Live site: [laserslicer.legradic.ch](https://laserslicer.legradic.ch)
 ![Screenshot of the Laser Slicer interface](screenshot.png)
@@ -10,7 +10,7 @@ Live site: [laserslicer.legradic.ch](https://laserslicer.legradic.ch)
 * A **browser 3‑D preview** of the stacked model
 * A **Dockerised, reproducible workflow** that runs the heavy lifting in Celery workers
 * **Fixed elevation** tool for clean coastlines and lakes
-* **SRTM noise filtering** for troublesome areas (e.g. Boston)
+* **DEM noise filtering** for troublesome areas (e.g. Boston)
 
 
 
@@ -22,8 +22,8 @@ Live site: [laserslicer.legradic.ch](https://laserslicer.legradic.ch)
 |-----------------------------------------|---------------------------------------|
 | **Leaflet map** – pick any address or drop a pin | **Geocoding** through Nominatim |
 | Auto geolocation start | `/api/elevation` single‑point query |
-| Parameter panel – slice height, base height, simplification | Fetch & clip **SRTM 30 m** DEM |
-| Minimum area/width filters & optional fixed elevation (lake) | Robust SRTM cleaning & outlier filtering |
+| Parameter panel – slice height, base height, simplification | Fetch & clip **SwissALTI3D 2 m** or SRTM 30 m DEM |
+| Minimum area/width filters & optional fixed elevation (lake) | Robust DEM cleaning & outlier filtering |
 | Toggle roads/buildings/waterways overlay | Fetch OSM roads, buildings & waterways |
 | **Slice** button launches background job | Contour generation with GDAL / Matplotlib |
 | Live **Three.js** 3‑D preview of layers | Optional simplification with Shapely |
@@ -143,5 +143,6 @@ Feel free to reach out via [GitHub](https://github.com/borsic77) or [email](mail
 
 ## Acknowledgements
 
-* NASA / NGA – SRTM data  
-* OpenStreetMap & Nominatim  
+* NASA / NGA – SRTM data
+* swisstopo – SwissALTI3D
+* OpenStreetMap & Nominatim

--- a/config/settings.py
+++ b/config/settings.py
@@ -57,6 +57,8 @@ if not DEBUG:
 # Directories for storing elevation files and cache
 
 TILE_CACHE_DIR = Path(get_env("TILE_CACHE_DIR", BASE_DIR / "data" / "srtm_cache"))
+ALTI3D_CACHE_DIR = Path(get_env("ALTI3D_CACHE_DIR", BASE_DIR / "data" / "alti3d_cache"))
+ALTI3D_DOWNLOADER = get_env("ALTI3D_DOWNLOADER", "alti3d-downloader")
 DEBUG_IMAGE_PATH = Path(get_env("DEBUG_IMAGE_PATH", BASE_DIR / "data" / "debug_images"))
 SVG_TMP_DIR = Path(get_env("SVG_TMP_DIR", BASE_DIR / "tmp" / "svg_tmp"))
 NOMINATIM_USER_AGENT = get_env("USER_AGENT", "laser-slicer/1.0 (contact@email.com)")

--- a/core/services/contour_generator.py
+++ b/core/services/contour_generator.py
@@ -9,7 +9,9 @@ from shapely.geometry import (
     shape,
 )
 
-from core.utils.download_clip_elevation_tiles import download_srtm_tiles_for_bounds
+from core.utils.download_clip_elevation_tiles import (
+    download_elevation_tiles_for_bounds,
+)
 from core.utils.geocoding import compute_utm_bounds_from_wgs84
 from core.utils.osm_features import (
     fetch_buildings,
@@ -233,7 +235,7 @@ class ContourSlicingJob:
         lon_min, lat_min, lon_max, lat_max = self.bounds
         cx, cy = self.center
         # Download elevation tiles and generate contours
-        tile_paths = download_srtm_tiles_for_bounds(self.bounds)
+        tile_paths = download_elevation_tiles_for_bounds(self.bounds)
         elevation, transform = mosaic_and_crop(tile_paths, self.bounds)
         # Clean the elevation data
         elevation = clean_srtm_dem(elevation)

--- a/core/services/elevation_service.py
+++ b/core/services/elevation_service.py
@@ -2,7 +2,9 @@ import logging
 
 import numpy as np
 
-from core.utils.download_clip_elevation_tiles import download_srtm_tiles_for_bounds
+from core.utils.download_clip_elevation_tiles import (
+    download_elevation_tiles_for_bounds,
+)
 from core.utils.dem import clean_srtm_dem, mosaic_and_crop
 
 logger = logging.getLogger(__name__)
@@ -35,7 +37,7 @@ class ElevationRangeJob:
         Returns:
             A dictionary with 'min' and 'max' elevation values.
         """
-        tile_paths = download_srtm_tiles_for_bounds(self.bounds)
+        tile_paths = download_elevation_tiles_for_bounds(self.bounds)
         elevation, _ = mosaic_and_crop(tile_paths, self.bounds)
         elevation = clean_srtm_dem(elevation)
         # elevation = robust_local_outlier_mask(elevation)

--- a/core/utils/download_clip_elevation_tiles.py
+++ b/core/utils/download_clip_elevation_tiles.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import subprocess
 from math import floor
 from pathlib import Path
 from typing import List, Tuple
@@ -10,6 +11,11 @@ from filelock import FileLock
 
 logger = logging.getLogger(__name__)
 TILE_CACHE_DIR = settings.TILE_CACHE_DIR
+ALTI3D_CACHE_DIR = settings.ALTI3D_CACHE_DIR
+ALTI3D_DOWNLOADER = settings.ALTI3D_DOWNLOADER
+
+# Swiss bounds (lon_min, lat_min, lon_max, lat_max)
+SWISS_BOUNDS = (5.95, 45.82, 10.49, 47.81)
 
 
 # Utility function to check for antimeridian crossing
@@ -122,3 +128,47 @@ def ensure_tile_downloaded(lat: float, lon: float) -> Path:
     paths = download_srtm_tiles_for_bounds(bounds)
     # There will be exactly one path in the returned list, matching our point
     return Path(paths[0])
+
+
+def within_swiss_bounds(bounds: Tuple[float, float, float, float]) -> bool:
+    """Check if bounds intersect Switzerland."""
+    lon_min, lat_min, lon_max, lat_max = bounds
+    s_lon_min, s_lat_min, s_lon_max, s_lat_max = SWISS_BOUNDS
+    return not (
+        lon_max < s_lon_min
+        or lon_min > s_lon_max
+        or lat_max < s_lat_min
+        or lat_min > s_lat_max
+    )
+
+
+def download_alti3d_tiles_for_bounds(
+    bounds: Tuple[float, float, float, float],
+) -> List[str]:
+    """Download SwissALTI3D tiles using the ``alti3d-downloader`` CLI."""
+    lon_min, lat_min, lon_max, lat_max = bounds
+    ALTI3D_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        ALTI3D_DOWNLOADER,
+        "--bbox",
+        f"{lon_min},{lat_min},{lon_max},{lat_max}",
+        "--resolution",
+        "2",
+        "--out",
+        str(ALTI3D_CACHE_DIR),
+    ]
+    logger.info("Running %s", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("alti3d-downloader failed: %s", exc)
+    return [str(p) for p in ALTI3D_CACHE_DIR.glob("*.tif")]
+
+
+def download_elevation_tiles_for_bounds(
+    bounds: Tuple[float, float, float, float],
+) -> List[str]:
+    """Download elevation tiles, preferring SwissALTI3D when in Switzerland."""
+    if within_swiss_bounds(bounds):
+        return download_alti3d_tiles_for_bounds(bounds)
+    return download_srtm_tiles_for_bounds(bounds)

--- a/env.example
+++ b/env.example
@@ -26,6 +26,8 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/0
 
 #data
 TILE_CACHE_DIR=/app/data/srtm_cache
+ALTI3D_CACHE_DIR=/app/data/alti3d_cache
+ALTI3D_DOWNLOADER=alti3d-downloader
 MEDIA_ROOT=/app/media
 
 # App-specific

--- a/tests/django_settings_stub.py
+++ b/tests/django_settings_stub.py
@@ -1,3 +1,5 @@
 DEBUG = False
-TILE_CACHE_DIR = '/tmp'
-DEBUG_IMAGE_PATH = '/tmp'
+TILE_CACHE_DIR = "/tmp"
+DEBUG_IMAGE_PATH = "/tmp"
+ALTI3D_CACHE_DIR = "/tmp"
+ALTI3D_DOWNLOADER = "alti3d-downloader"

--- a/tests/test_download_tiles.py
+++ b/tests/test_download_tiles.py
@@ -5,6 +5,7 @@ from core.utils.download_clip_elevation_tiles import (
     ensure_tile_downloaded,
     get_srtm_tile_path,
     is_antimeridian_crossing,
+    within_swiss_bounds,
 )
 
 
@@ -78,6 +79,17 @@ def test_is_antimeridian_crossing(bounds, expected):
     assert is_antimeridian_crossing(bounds) is expected
 
 
+@pytest.mark.parametrize(
+    "bounds,expected",
+    [
+        ((6.5, 46.7, 6.7, 46.9), True),
+        ((0.0, 0.0, 1.0, 1.0), False),
+    ],
+)
+def test_within_swiss_bounds(bounds, expected):
+    assert within_swiss_bounds(bounds) is expected
+
+
 def test_get_srtm_tile_path(tmp_path):
     path1 = get_srtm_tile_path(46.8, 6.6, tmp_path)
     assert path1 == tmp_path / "N46E006.hgt.gz"
@@ -93,7 +105,9 @@ def test_get_srtm_tile_path(tmp_path):
         (-16.2, -179.9, (-180, -17, -179, -16), "S17W180.hgt.gz"),
     ],
 )
-def test_ensure_tile_downloaded(monkeypatch, tmp_path, lat, lon, expected_bounds, filename):
+def test_ensure_tile_downloaded(
+    monkeypatch, tmp_path, lat, lon, expected_bounds, filename
+):
     def fake_download(bounds):
         assert bounds == expected_bounds
         return [str(tmp_path / filename)]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -61,7 +61,8 @@ def test_contour_slicing_job_run(monkeypatch):
         return fake_contours
 
     monkeypatch.setattr(
-        "core.services.contour_generator.download_srtm_tiles_for_bounds", fake_download
+        "core.services.contour_generator.download_elevation_tiles_for_bounds",
+        fake_download,
     )
     monkeypatch.setattr("core.services.contour_generator.mosaic_and_crop", fake_mosaic)
     monkeypatch.setattr("core.services.contour_generator.clean_srtm_dem", lambda x: x)
@@ -125,7 +126,7 @@ def test_contour_slicing_job_with_osm(monkeypatch):
     ml = shapely.geometry.MultiLineString([[(0, 0), (1, 0)]])
 
     monkeypatch.setattr(
-        "core.services.contour_generator.download_srtm_tiles_for_bounds",
+        "core.services.contour_generator.download_elevation_tiles_for_bounds",
         lambda b: ["tile"],
     )
     monkeypatch.setattr(
@@ -198,7 +199,7 @@ def test_contour_slicing_job_empty_osm(monkeypatch):
     poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 0)])
 
     monkeypatch.setattr(
-        "core.services.contour_generator.download_srtm_tiles_for_bounds",
+        "core.services.contour_generator.download_elevation_tiles_for_bounds",
         lambda b: ["tile"],
     )
     monkeypatch.setattr(
@@ -273,7 +274,7 @@ def test_elevation_range_job(monkeypatch):
     """ElevationRangeJob.run returns min and max elevations."""
     arr = np.array([[100, 200], [300, 400]], dtype=float)
     monkeypatch.setattr(
-        "core.services.elevation_service.download_srtm_tiles_for_bounds",
+        "core.services.elevation_service.download_elevation_tiles_for_bounds",
         lambda b: ["tile"],
     )
     monkeypatch.setattr(
@@ -293,7 +294,7 @@ def test_elevation_range_job_invalid(monkeypatch):
     """ElevationRangeJob.run raises ElevationDataError when DEM is invalid."""
     arr = np.array([[np.nan, np.nan]])
     monkeypatch.setattr(
-        "core.services.elevation_service.download_srtm_tiles_for_bounds",
+        "core.services.elevation_service.download_elevation_tiles_for_bounds",
         lambda b: ["tile"],
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- download SwissALTI3D elevation data when slicing area is in Switzerland
- configure cache paths and downloader command
- document the new data source
- update tests and settings stub

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for celery, geopandas, etc.)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fea41516083268b45c5608d0aa9cb